### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,11 +120,11 @@ Other Python Security Tools
     :target: https://github.com/jhermann/dependency-check-py/issues
 .. |License| image:: https://img.shields.io/pypi/l/dependency-check.svg
     :target: https://github.com/jhermann/dependency-check-py/blob/master/LICENSE
-.. |Development Status| image:: https://pypip.in/status/dependency-check/badge.svg
+.. |Development Status| image:: https://img.shields.io/pypi/status/dependency-check.svg
     :target: https://pypi.python.org/pypi/dependency-check/
 .. |Latest Version| image:: https://img.shields.io/pypi/v/dependency-check.svg
     :target: https://pypi.python.org/pypi/dependency-check/
-.. |Download format| image:: https://pypip.in/format/dependency-check/badge.svg
+.. |Download format| image:: https://img.shields.io/pypi/format/dependency-check.svg
     :target: https://pypi.python.org/pypi/dependency-check/
 .. |Downloads| image:: https://img.shields.io/pypi/dw/dependency-check.svg
     :target: https://pypi.python.org/pypi/dependency-check/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20dependency-check))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `dependency-check`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.