### PR TITLE
Chore: Remove reference to archived product repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,6 @@ Other Python Security Tools
   * `pyupio/safety-db`_ – A curated database of security vulnerabilities in Python packages.
 
 * `eliasgranderubio/dagda`_ – Static analysis of known vulnerabilities, trojans, viruses, malware & other malicious threats in Docker images, and runtime monitoring of containers for anomalous activities.
-* `anchore/anchore-engine`_ – A service for inspection, analysis and certification of container images, provided as a ready-to-deploy Docker container image.
 * `sonatype-nexus-community/jake`_ – An OSS Index integration to check your Conda environments for vulnerable Open Source packages.
 
 * `vintasoftware/python-linters-and-code-analysis`_ – Curated list of Python linters and code analysis tools.
@@ -127,7 +126,6 @@ Other Python Security Tools
 .. _`pyupio/safety`: https://github.com/pyupio/safety
 .. _`pyupio/safety-db`: https://github.com/pyupio/safety-db
 .. _`eliasgranderubio/dagda`: https://github.com/eliasgranderubio/dagda
-.. _`anchore/anchore-engine`: https://github.com/anchore/anchore-engine
 .. _`vintasoftware/python-linters-and-code-analysis`: https://github.com/vintasoftware/python-linters-and-code-analysis
 .. _`sonatype-nexus-community/jake`: https://github.com/sonatype-nexus-community/jake
 


### PR DESCRIPTION
👋 Hullo there!

Anchore Engine, mentioned in the README (and thus in the PyPi page), is no longer supported, so the repo has been archived. 

It has been replaced by our Open Source tools, [Syft](https://github.com/anchore/syft), [Grype](https://github.com/anchore/grype), written in Go, and our SCA platform (which *is* written in Python) - [Anchore Enterprise](https://anchore.com/platform/).

Our web people tell me that the PyPi [dependency-check](https://pypi.org/project/dependency-check/) page still ranks quite highly, thus exposing these archived projects to a surprising number of eyeballs! :) 

Would you mind removing the link to reduce confusion 🙏 

Thanks!